### PR TITLE
[codex] Add agenttrace to agent-friendly tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Tools that are not orchestrators themselves, but make multi-agent systems easier
 
 - [Agent Analytics](https://agentanalytics.sh/) - Web analytics for builders that Claude Code, Codex, Cursor, OpenClaw, Paperclip, and similar AI agents can use.
 - [ClawTrace](https://www.clawtrace.ai/?ref=producthunt) - Observability for OpenClaw agents that shows what failed, where spend leaked, and how to improve runs.
+- [agenttrace](https://github.com/luoyuctl/agenttrace) - Local TUI observability for AI coding-agent sessions, tokens, cost, tool failures, latency, anomalies, diffs, and CI evidence.
 - [Companies.sh](https://companies.sh/) - Reusable companies for AI agents: pre-built organizations that can be installed with a single command.
 
 ## Implementation Services

--- a/src/data/orchestrators.ts
+++ b/src/data/orchestrators.ts
@@ -125,6 +125,18 @@ export const orchestrationTools: OrchestrationToolEntry[] = [
     tags: ["observability", "OpenClaw", "tracing"]
   },
   {
+    slug: "agenttrace",
+    title: "agenttrace",
+    url: "https://github.com/luoyuctl/agenttrace",
+    sourceName: "agenttrace GitHub repository",
+    mark: "AT",
+    summary:
+      "Local TUI observability for AI coding-agent sessions, tokens, cost, tool failures, latency, anomalies, diffs, and CI evidence.",
+    note:
+      "Parses local logs from Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, OpenClaw, and related coding agents so builders can inspect session health without sending prompts or code to a hosted tracing service.",
+    tags: ["observability", "coding agents", "TUI", "local-first"]
+  },
+  {
     slug: "lanes",
     title: "Lanes",
     url: "https://lanes.sh/",


### PR DESCRIPTION
## What changed

- Added `agenttrace` to the agent-friendly tooling data set.
- Added the matching README entry under Agent-Friendly Tooling.

## Why it belongs

`agenttrace` is not an orchestrator runtime. It fits this section as a local observability tool for AI coding-agent sessions across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, OpenClaw, and related logs.

## Source

- Official GitHub repository: https://github.com/luoyuctl/agenttrace

## Validation

- `npm test`
- `npm run build`
