### PR TITLE
Add the-perfect-orchestrator to the directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The public website is [Open Orchestrators](https://openorchestrators.org/). This
 
 ## Latest Additions
 
+- [the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator) ([Website](https://the-perfect-orchestrator.vercel.app/), [Recorded fleet run](https://github.com/daman8271/the-perfect-orchestrator/tree/main/docs/realrun-2026-06-06)) - MIT-licensed bash and tmux harness where one lead Claude Code session spawns, briefs, monitors, and adversarially verifies multiple autonomous worker sessions, with plain-file coordination and no daemons.
 - [Helmor](https://helmor.ai/) ([GitHub](https://github.com/dohooo/helmor), [Releases](https://github.com/dohooo/helmor/releases)) - Apache-2.0 local-first IDE and workbench for orchestrating Claude Code, Codex, and other coding agents across worktrees through planning, running, review, testing, merge, and shipping loops.
 - [Open Swarm](https://openswarm.com/) ([GitHub](https://github.com/openswarm-ai/openswarm), [Docs](https://docs.openswarm.com), [Releases](https://github.com/openswarm-ai/openswarm/releases)) - MIT-licensed local mission-control center for launching, monitoring, approving, and coordinating multiple AI agents in parallel.
 - [oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) ([Website](https://yeachan-heo.github.io/oh-my-codex-website/), [npm](https://www.npmjs.com/package/oh-my-codex)) - MIT-licensed workflow layer for OpenAI Codex CLI with stronger default sessions, reusable skills, native hooks, HUD/status surfaces, project guidance, and team-style execution commands.
@@ -66,6 +67,7 @@ Tools for running multiple coding agents simultaneously, usually with git worktr
 - [Sandcastle](https://github.com/mattpocock/sandcastle) ([npm](https://www.npmjs.com/package/@ai-hero/sandcastle)) - MIT-licensed TypeScript library and CLI for orchestrating AI coding agents in isolated sandboxes with branch strategies, hooks, logs, templates, and merge-back workflows.
 - [oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) ([Website](https://yeachan-heo.github.io/oh-my-codex-website/), [npm](https://www.npmjs.com/package/oh-my-codex)) - Workflow layer for OpenAI Codex CLI with reusable skills, native hooks, HUD/status surfaces, project guidance, and `$team`/`$ralph` execution commands.
 - [Vibe Kanban](https://vibekanban.com/) ([GitHub](https://github.com/BloopAI/vibe-kanban)) - Kanban workspace for planning issues, running coding agents in branches with terminals and dev servers, reviewing diffs, previewing apps, opening pull requests, and merging finished work.
+- [the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator) ([Website](https://the-perfect-orchestrator.vercel.app/)) - MIT-licensed bash and tmux harness where one lead Claude Code session spawns, briefs, monitors, and adversarially verifies multiple autonomous worker sessions through plain-file coordination, with no daemons.
 
 ## Multi-Agent Platforms And Builders
 

--- a/src/data/orchestrators.ts
+++ b/src/data/orchestrators.ts
@@ -2060,5 +2060,52 @@ export const orchestrators: OrchestratorEntry[] = [
         }
       ]
     }
+  },
+  {
+    slug: "the-perfect-orchestrator",
+    rank: 30,
+    title: "the-perfect-orchestrator",
+    githubRepo: "daman8271/the-perfect-orchestrator",
+    accent: "emerald",
+    mark: {
+      kind: "monogram",
+      value: "PO",
+      label: "the-perfect-orchestrator monogram"
+    },
+    summary:
+      "A pure bash and tmux fleet harness where one lead Claude Code session spawns, briefs, monitors, and adversarially verifies multiple autonomous Claude Code worker sessions.",
+    note:
+      "Centers orchestration on a lead-session pattern: workers run as tmux panes, coordination happens through plain files on disk, and worker results pass adversarial verification before being accepted.",
+    overview: [
+      "the-perfect-orchestrator is an MIT-licensed bash and tmux harness for running one lead Claude Code session that commands multiple autonomous worker sessions. There are no daemons or services: workers are tmux panes, briefs and results are markdown files, and inter-agent messaging is a plain-file bus.",
+      "It belongs in Open Orchestrators because the orchestration layer is the product: spawning and briefing workers, monitoring their panes, file-based coordination, and adversarial verification of worker output. It also installs as a Claude Code plugin that ships an /orch skill. The project is early (v0.2.0) and publishes a recorded real fleet run with raw transcripts as its public verification source."
+    ],
+    bestFor: ["Parallel Claude Code worker fleets", "File-based agent coordination", "Adversarial verification of agent results"],
+    tags: ["bash", "tmux", "claude code", "adversarial verification", "MIT"],
+    links: [
+      {
+        label: "GitHub",
+        href: "https://github.com/daman8271/the-perfect-orchestrator",
+        emphasis: "primary"
+      },
+      {
+        label: "Website",
+        href: "https://the-perfect-orchestrator.vercel.app/"
+      },
+      {
+        label: "Recorded fleet run",
+        href: "https://github.com/daman8271/the-perfect-orchestrator/tree/main/docs/realrun-2026-06-06"
+      }
+    ],
+    screenshots: [],
+    agentAnalytics: agentAnalyticsSection(
+      "the-perfect-orchestrator",
+      "the-perfect-orchestrator",
+      "the-perfect-orchestrator runs a lead Claude Code session that ships work through verified tmux worker fleets. Agent Analytics measures whether the surfaces those fleets change actually move users.",
+      ["a lead session briefs tmux workers to change a website, docs flow, onboarding path, app surface, demo, or experiment", "the changed surface reports visits, sources, CTA clicks, signup, activation, retention, or task-completion events to Agent Analytics", "the lead session or a follow-up worker fetches Agent Analytics results after deployment", "the next fleet run is briefed from measured user outcomes instead of only verified task completion"],
+      "Instrument the deployed surface affected by fleet-managed commits. Agent Analytics reads product and web events after the change ships; it does not replace the harness's own bus messages, worker transcripts, or adversarial verification verdicts.",
+      "fleet-managed page, docs path, traffic source, CTA click, signup, activation event, retention signal, or shipped experiment",
+      []
+    )
   }
 ];


### PR DESCRIPTION
Adds [the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator) as a directory entry (rank 30) in `src/data/orchestrators.ts`, plus README Latest Additions and Parallel Coding-Agent Runners lines.

Scope fit: parallel coding-agent execution + multi-agent coordination — one lead Claude Code session spawns, briefs, monitors, and adversarially verifies N autonomous worker sessions in tmux; plain-file coordination, no daemons. MIT.

Verification sources (per CONTRIBUTING): the [GitHub repo](https://github.com/daman8271/the-perfect-orchestrator), the [live site](https://the-perfect-orchestrator.vercel.app/), and a [recorded real fleet run with raw transcripts](https://github.com/daman8271/the-perfect-orchestrator/tree/main/docs/realrun-2026-06-06). Disclosure: the project is new (v0.2.0, days old) and I'm the author. Copy kept factual per your sourcing rules; used a monogram mark and no screenshots to avoid hotlinking assets. `npx astro build` passes locally (69 pages, including the new player page).