### PR TITLE
Add handoff — cross-agent task dispatcher for Claude Code / Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The public website is [Open Orchestrators](https://openorchestrators.org/). This
 - [SIDJUA](https://www.sidjua.com/) ([GitHub](https://github.com/GoetzKohlberg/sidjua)) - Governance-first AI agent orchestration platform with pre-action controls, budgets, approvals, classifications, and audit trails.
 - [Agentix Labs](https://www.agentixlabs.com/) - Implementation services entry, tracked separately from orchestrators because it helps teams deploy and harden production agent systems.
 - [SettleBridge](https://settlebridge.ai/) ([GitHub org](https://github.com/a2a-settlement)) - Trust and policy gateway for agent-to-agent settlement, reputation checks, spending limits, provenance requirements, escrow, dispute resolution, marketplace bounties, and cryptographic audit trails.
+- [handoff](https://github.com/dazuiba/handoff) ([GitHub](https://github.com/dazuiba/handoff)) - MIT cross-agent task dispatcher; delegate work to DeepSeek V4, Codex, or Opus without leaving your Claude Code / Codex session. Runs in background, result returns automatically.
 
 ## Contents
 


### PR DESCRIPTION
## What is handoff?

[handoff](https://github.com/dazuiba/handoff) is a skill/subagent (backed by handoff-cli) that lets you delegate tasks to DeepSeek V4, Codex, or Claude Opus right inside your Claude Code / Codex session — without switching tools or losing context.

- Runs the delegated task in the background; your session never blocks
- Result comes back automatically when the task finishes
- Supports parallel tasks and resuming past sessions

## Why it belongs here

handoff is a multi-agent orchestration tool that routes tasks between Claude Code, Codex, and DeepSeek agents.

## Links

- GitHub: https://github.com/dazuiba/handoff
- Install: `uv tool install handoff-cli && handoff init`
