### PR TITLE
Add Boardroom to orchestrators directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The public website is [Open Orchestrators](https://openorchestrators.org/). This
 
 ## Latest Additions
 
+- [Boardroom](https://github.com/jamiejhouston-commits/boardroom) - Local-first iPhone command center that turns Hermes Agent into an autonomous company with boardroom debates, human greenlights, Mac relay execution, and Demo Day review.
 - [Helmor](https://helmor.ai/) ([GitHub](https://github.com/dohooo/helmor), [Releases](https://github.com/dohooo/helmor/releases)) - Apache-2.0 local-first IDE and workbench for orchestrating Claude Code, Codex, and other coding agents across worktrees through planning, running, review, testing, merge, and shipping loops.
 - [Open Swarm](https://openswarm.com/) ([GitHub](https://github.com/openswarm-ai/openswarm), [Docs](https://docs.openswarm.com), [Releases](https://github.com/openswarm-ai/openswarm/releases)) - MIT-licensed local mission-control center for launching, monitoring, approving, and coordinating multiple AI agents in parallel.
 - [oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) ([Website](https://yeachan-heo.github.io/oh-my-codex-website/), [npm](https://www.npmjs.com/package/oh-my-codex)) - MIT-licensed workflow layer for OpenAI Codex CLI with stronger default sessions, reusable skills, native hooks, HUD/status surfaces, project guidance, and team-style execution commands.
@@ -88,6 +89,7 @@ Frameworks and product surfaces for creating agents, teams, workflows, chatflows
 
 Systems where the central object is the team, company, room, protocol, role, goal, job, or handoff layer between agents.
 
+- [Boardroom](https://github.com/jamiejhouston-commits/boardroom) - Local-first iPhone command center for running Hermes Agent like an autonomous company, with boardroom debates, human greenlights, Mac relay execution, meetings, memos, and Demo Day review.
 - [CrewAI](https://www.crewai.com/) ([GitHub](https://github.com/crewAIInc/crewAI)) - Multi-agent system organized around specialized crews, roles, and delegation.
 - [Squad](https://bradygaster.github.io/squad/) ([GitHub](https://github.com/bradygaster/squad)) - Alpha GitHub Copilot-based system where specialist agents live in the repo, keep memory, share decisions, route work through a coordinator, and run in parallel.
 - [Culture](https://culture.dev/) ([GitHub](https://github.com/agentculture/culture)) - Coordination-oriented system with rooms, protocol docs, agent lifecycle patterns, and multiple clients.

--- a/src/data/orchestrators.ts
+++ b/src/data/orchestrators.ts
@@ -319,6 +319,8 @@ const hermesScreenshots = [
   screenshot("hermes", "Hermes Agent", "Hermes Agent website", "https://hermes-agent.nousresearch.com/")
 ];
 
+const boardroomScreenshots: OrchestratorScreenshot[] = [];
+
 const simScreenshots = [
   screenshot("sim", "Sim", "Sim website", "https://www.sim.ai/")
 ];
@@ -941,6 +943,68 @@ export const orchestrators: OrchestratorEntry[] = [
       "Install Agent Analytics on the project surfaces AgentRQ agents change. Agent Analytics measures user behavior after deployment; it is not a replacement for AgentRQ's task board, MCP notification channels, approval queue, or workspace state.",
       "AgentRQ-coordinated page, docs path, traffic source, CTA click, signup, activation event, approval flow, funnel step, or shipped task",
       agentRqScreenshots
+    )
+  },
+  {
+    slug: "boardroom",
+    rank: 31,
+    title: "Boardroom",
+    githubRepo: "jamiejhouston-commits/boardroom",
+    accent: "violet",
+    mark: {
+      kind: "monogram",
+      value: "BR",
+      label: "Boardroom monogram"
+    },
+    summary:
+      "A local-first iPhone command center that turns Hermes Agent into an autonomous company with boardroom debates, human greenlights, and Demo Day review.",
+    note:
+      "Centers orchestration on the founder-as-chairman workflow: scout, research, debate, approve, build, and review through an iPhone app connected to a Mac relay.",
+    overview: [
+      "Boardroom is a public-source iOS app for running Hermes Agent like an autonomous company from an iPhone. The README describes a local-first iPhone and Mac relay setup where agents scout trends, debate what to build, file meeting minutes, produce deliverables on the Mac, and ask the human for greenlight and ship/no-ship decisions.",
+      "It belongs in Open Orchestrators because the product is explicitly organized around agent-company operations rather than a single chat surface: leadership roles, boardroom debates, voice/chat, scheduled meetings, memos, budgets, quiet hours, a kill switch, human approval, and Demo Day review."
+    ],
+    bestFor: [
+      "Founder-controlled agent-company workflows",
+      "Hermes Agent on an owned Mac",
+      "Human greenlight and Demo Day governance"
+    ],
+    tags: ["Hermes Agent", "iOS", "local-first", "company OS", "human in the loop"],
+    links: [
+      {
+        label: "GitHub",
+        href: "https://github.com/jamiejhouston-commits/boardroom",
+        emphasis: "primary"
+      },
+      {
+        label: "Hermes Agent",
+        href: "https://hermes-agent.nousresearch.com/"
+      }
+    ],
+    screenshots: boardroomScreenshots,
+    agentAnalytics: agentAnalyticsSection(
+      "boardroom",
+      "Boardroom",
+      "Boardroom turns agent work into founder-controlled product and company operations. Agent Analytics gives the follow-up operator measurable visitor, source, funnel, and conversion data after a Boardroom-managed deliverable reaches users.",
+      [
+        "a Boardroom company scouts, debates, and receives human greenlight for a user-facing deliverable",
+        "the approved work ships to a website, docs path, app page, onboarding flow, demo, or campaign surface",
+        "the changed surface reports visits, sources, CTA clicks, signup, activation, retention, funnels, and conversion events to Agent Analytics",
+        "a later Boardroom meeting or Demo Day review uses the measured outcome to decide whether to iterate, kill, or scale the work"
+      ],
+      "Install Agent Analytics on the surfaces Boardroom-managed agents change. The useful loop starts after the founder-approved work ships: a later agent can read real user behavior before proposing the next greenlight decision.",
+      "Boardroom-managed page, traffic source, CTA click, signup, activation event, funnel step, Demo Day outcome, or shipped deliverable",
+      boardroomScreenshots,
+      [
+        {
+          label: "Boardroom GitHub repository",
+          href: "https://github.com/jamiejhouston-commits/boardroom"
+        },
+        {
+          label: "Hermes Agent docs",
+          href: "https://hermes-agent.nousresearch.com/docs"
+        }
+      ]
     )
   },
   {


### PR DESCRIPTION
## Summary
- add Boardroom as a public-source multi-agent/company OS entry
- list it in Latest Additions and Coordination And Team Systems
- source facts from the public Boardroom README and repository description

## Source used
- https://github.com/jamiejhouston-commits/boardroom
- README states the iPhone + Mac relay, Hermes Agent dependency, boardroom debates, human greenlight, meetings/memos, and Demo Day workflow.

## Checks
- `npm run build`
- `npm test`