### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Tools that are not orchestrators themselves, but make multi-agent systems easier
 
 - [Agent Analytics](https://agentanalytics.sh/) - Web analytics for builders that Claude Code, Codex, Cursor, OpenClaw, Paperclip, and similar AI agents can use.
 - [ClawTrace](https://www.clawtrace.ai/?ref=producthunt) - Observability for OpenClaw agents that shows what failed, where spend leaked, and how to improve runs.
+- [Future AGI](https://github.com/future-agi/future-agi) ([GitHub](https://github.com/future-agi/future-agi)) - Open-source platform to simulate, evaluate, trace, guardrail, route, and optimize LLM and AI agent apps in one feedback loop, so agents don't just get monitored, they self-improve. Self-hostable. Apache-2.0.
+
 - [Companies.sh](https://companies.sh/) - Reusable companies for AI agents: pre-built organizations that can be installed with a single command.
 
 ## Implementation Services

--- a/src/data/orchestrators.ts
+++ b/src/data/orchestrators.ts
@@ -125,6 +125,18 @@ export const orchestrationTools: OrchestrationToolEntry[] = [
     tags: ["observability", "OpenClaw", "tracing"]
   },
   {
+    slug: "future-agi",
+    title: "Future AGI",
+    url: "https://github.com/future-agi/future-agi",
+    sourceName: "Future AGI GitHub repository",
+    mark: "FA",
+    summary:
+      "Open-source platform to simulate, evaluate, trace, guardrail, route, and optimize multi-agent apps in one feedback loop, so agents don't just get monitored, they self-improve.",
+    note:
+      "Adds OpenTelemetry-native tracing across agent frameworks, 70+ eval metrics with LLM-as-judge, real-time guardrails for prompt injection, jailbreak, PII, and toxicity, plus persona simulation and prompt/agent optimization. Self-hostable, Apache-2.0. Tracked as agent-friendly tooling, not an orchestrator runtime.",
+    tags: ["open source", "Apache-2.0", "evaluation", "tracing", "guardrails", "optimization"]
+  },
+  {
     slug: "lanes",
     title: "Lanes",
     url: "https://lanes.sh/",


### PR DESCRIPTION
This PR adds FutureAGI to the Agent-Friendly Tooling section.

FutureAGI is an open-source platform for building reliable AI agents. Simulate against personas, trace every step with OTel-native instrumentation, evaluate across 70+ metrics, and deploy guardrails, all in one feedback loop. | Apache 2.0 | Self-hostable

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with FutureAGI.