### PR TITLE
Add Agon

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The public website is [Open Orchestrators](https://openorchestrators.org/). This
 
 ## Latest Additions
 
+- [Agon](https://github.com/AutoResearch-Factory/Agon) ([Paper](https://arxiv.org/abs/2606.24177)) - Autonomous research system that coordinates scientist, coder, and auditor loops from topic to idea, proposal, experiment, and paper.
 - [Helmor](https://helmor.ai/) ([GitHub](https://github.com/dohooo/helmor), [Releases](https://github.com/dohooo/helmor/releases)) - Apache-2.0 local-first IDE and workbench for orchestrating Claude Code, Codex, and other coding agents across worktrees through planning, running, review, testing, merge, and shipping loops.
 - [Open Swarm](https://openswarm.com/) ([GitHub](https://github.com/openswarm-ai/openswarm), [Docs](https://docs.openswarm.com), [Releases](https://github.com/openswarm-ai/openswarm/releases)) - MIT-licensed local mission-control center for launching, monitoring, approving, and coordinating multiple AI agents in parallel.
 - [oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) ([Website](https://yeachan-heo.github.io/oh-my-codex-website/), [npm](https://www.npmjs.com/package/oh-my-codex)) - MIT-licensed workflow layer for OpenAI Codex CLI with stronger default sessions, reusable skills, native hooks, HUD/status surfaces, project guidance, and team-style execution commands.
@@ -71,6 +72,7 @@ Tools for running multiple coding agents simultaneously, usually with git worktr
 
 Frameworks and product surfaces for creating agents, teams, workflows, chatflows, agent apps, or production agent runtimes.
 
+- [Agon](https://github.com/AutoResearch-Factory/Agon) ([Paper](https://arxiv.org/abs/2606.24177)) - Autonomous research system that coordinates scientist, coder, and auditor loops from topic to idea, proposal, experiment, and paper.
 - [Agno](https://agno.com/) ([GitHub](https://github.com/agno-agi/agno)) - Production runtime for agentic software with agents, teams, workflows, and AgentOS services.
 - [Agent Office Suite](https://www.agentofficesuite.com/) ([GitHub](https://github.com/manpoai/AgentOfficeSuite), [Manpo X](https://x.com/manpoai)) - Self-hosted office suite where agents collaborate with humans on docs, databases, slides, and flowcharts through MCP, contextual comments, version history, and traceable edits.
 - [Cabinet](https://runcabinet.com/) ([GitHub](https://github.com/hilash/cabinet)) - AI-first knowledge base where files live on disk and agents help with execution.

--- a/src/data/orchestrators.ts
+++ b/src/data/orchestrators.ts
@@ -368,6 +368,8 @@ const agnoScreenshots = [
   screenshot("agno", "Agno", "Agno website", "https://agno.com/")
 ];
 
+const agonScreenshots = [];
+
 const agentOfficeSuiteScreenshots = [
   screenshot("agent-office-suite", "Agent Office Suite", "Agent Office Suite website", "https://www.agentofficesuite.com/")
 ];
@@ -2119,5 +2121,59 @@ export const orchestrators: OrchestratorEntry[] = [
         }
       ]
     }
+  },
+  {
+    slug: "agon",
+    rank: 31,
+    title: "Agon",
+    githubRepo: "AutoResearch-Factory/Agon",
+    accent: "violet",
+    mark: {
+      kind: "monogram",
+      value: "Ag",
+      label: "Agon monogram"
+    },
+    summary:
+      "An autonomous research system that coordinates scientist, coder, and auditor loops from topic to idea, proposal, experiment, and paper.",
+    note:
+      "Centers orchestration on compact prompt loops, zero-code dispatch, independent critique, and human checkpoints for long-running scientific research.",
+    overview: [
+      "Agon is an autonomous research system for running scientific workflows from a topic through idea generation, proposal writing, experiment execution, and paper drafting.",
+      "It belongs in Open Orchestrators because the repository is organized around multi-agent research loops rather than a single assistant: scientist, coder, and auditor roles are dispatched through reusable prompts, with critics used to break outputs before the workflow moves forward.",
+      "The public repository includes setup instructions and agent, command, reference, and skill artifacts. The accompanying paper frames the design around Prompt Economy and zero-code orchestration."
+    ],
+    bestFor: ["Autonomous research loops", "Scientist-coder-auditor workflows", "Prompt-based orchestration"],
+    tags: ["research agents", "multi-agent", "prompt loops", "scientific workflows"],
+    links: [
+      {
+        label: "GitHub",
+        href: "https://github.com/AutoResearch-Factory/Agon",
+        emphasis: "primary"
+      },
+      {
+        label: "Paper",
+        href: "https://arxiv.org/abs/2606.24177"
+      }
+    ],
+    screenshots: agonScreenshots,
+    agentAnalytics: agentAnalyticsSection(
+      "agon",
+      "Agon",
+      "Agon can run long research loops that produce project pages, papers, demos, docs, and benchmark artifacts. Agent Analytics gives the human operator a way to measure whether those public surfaces reached readers and users after release.",
+      ["an Agon run produces or updates a research page, docs path, demo, benchmark artifact, or paper companion site", "the released surface reports visits, sources, CTA clicks, downloads, signups, paper clicks, or benchmark interactions to Agent Analytics", "a follow-up agent fetches the Agent Analytics results after the release", "the operator uses the measured outcome to decide which research artifact, demo, or explanation to improve next"],
+      "Instrument the public surface created around the Agon output. Agent Analytics measures user-facing web and product events; it does not replace Agon's internal auditor reports, run logs, or human scientific judgment.",
+      "Agon-built research page, docs path, paper link, demo, benchmark artifact, traffic source, or release outcome",
+      agonScreenshots,
+      [
+        {
+          label: "Agon paper",
+          href: "https://arxiv.org/abs/2606.24177"
+        },
+        {
+          label: "Agon GitHub repository",
+          href: "https://github.com/AutoResearch-Factory/Agon"
+        }
+      ]
+    )
   }
 ];


### PR DESCRIPTION
Adds Agon to the directory and README.\n\nPublic sources: the GitHub repo and paper. It fits as a multi-agent research orchestration system built around prompt loops and human checkpoints.