### PR TITLE
Add Open Agent Relay to supporting tools

### DIFF
--- a/src/data/orchestrators.ts
+++ b/src/data/orchestrators.ts
@@ -150,6 +150,19 @@ export const orchestrationTools: OrchestrationToolEntry[] = [
       "Runs Claude Code, Codex, Cursor, and other coding agents behind a shared workbench with containerized disk/network isolation, tasks, diffs, artifacts, unified transcripts, and review. Tracked as an ADE/workspace layer for teams standardizing agent work, not as a product analytics system.",
     tags: ["ADE", "coding agents", "containers", "transcripts", "review"],
     ctaLabel: "Open ctx"
+  },
+  {
+    slug: "open-agent-relay",
+    title: "Open Agent Relay",
+    url: "https://github.com/ShakespeareLabs/open-agent-relay",
+    sourceName: "Open Agent Relay GitHub repository",
+    mark: "OAR",
+    summary:
+      "Apache-2.0 relay for exposing existing local agents as capabilities callable by teammates and other agents over a trusted LAN.",
+    note:
+      "Keeps source code, runtime dependencies, prompts, and credentials on the publishing machine while callers use a lightweight CLI with JSON output, agent identity checks, meaningful exit codes, and bounded conversations. Tracked as an agent capability-sharing and coordination-adjacent tool, not as an orchestrator runtime.",
+    tags: ["open source", "local-first", "agent relay", "capability sharing", "CLI"],
+    ctaLabel: "Open relay"
   }
 ];
 


### PR DESCRIPTION
Adds Open Agent Relay to the supporting orchestration tools data.

Why it belongs: Open Agent Relay exposes existing local agents as capabilities callable by teammates and other agents over a trusted LAN. It keeps source code, dependencies, prompts, and credentials on the publishing host and provides CLI-oriented JSON output, agent identity checks, exit codes, and bounded conversations.

The entry explicitly describes it as a capability-sharing and coordination-adjacent tool, not as an orchestrator runtime.

Public verification source: https://github.com/ShakespeareLabs/open-agent-relay

Validation:
- npm test: 4/4 passed
- npm run build: 72 pages built successfully