### PR TITLE
Add Agent Coordinator to agent-friendly tooling

### DIFF
--- a/src/data/orchestrators.ts
+++ b/src/data/orchestrators.ts
@@ -150,6 +150,18 @@ export const orchestrationTools: OrchestrationToolEntry[] = [
       "Runs Claude Code, Codex, Cursor, and other coding agents behind a shared workbench with containerized disk/network isolation, tasks, diffs, artifacts, unified transcripts, and review. Tracked as an ADE/workspace layer for teams standardizing agent work, not as a product analytics system.",
     tags: ["ADE", "coding agents", "containers", "transcripts", "review"],
     ctaLabel: "Open ctx"
+  },
+  {
+    slug: "agent-coordinator",
+    title: "Agent Coordinator",
+    url: "https://github.com/alanhoff/agent-coordinator",
+    sourceName: "Agent Coordinator GitHub repository",
+    mark: "AC",
+    summary:
+      "Per-user Codex skill that represents complex tasks as bounded work graphs and records revisioned local state.",
+    note:
+      "Keeps graph changes, integration, reconciliation, and completion under one parent task; nodes can run inline or through optional specialists, uncertain work is reconciled before retry, and planned checks run again at closeout; this directory tracks it as Codex workflow tooling rather than a standalone orchestrator runtime.",
+    tags: ["Codex", "work graphs", "local state", "reconciliation", "agent workflows"]
   }
 ];
 


### PR DESCRIPTION
## What changed

- Added Agent Coordinator to the agent-friendly tooling data.
- Kept it out of the main orchestrator ranking.

## Why it belongs

Agent Coordinator is a per-user Codex skill for bounded work graphs, revisioned local state, reconciliation before retry, and closeout checks. Nodes can run inline or through optional specialists, so the supporting-tooling track is a more accurate fit than the standalone orchestrator directory.

## Public source

- Repository: https://github.com/alanhoff/agent-coordinator
- Source reviewed: https://github.com/alanhoff/agent-coordinator/tree/fb3d64688a9e1b7c02a114a14faac1219ec10f51
- License: https://github.com/alanhoff/agent-coordinator/blob/fb3d64688a9e1b7c02a114a14faac1219ec10f51/LICENSE

## Validation

- `npm test`
- `npm run build`
- `git diff --check`
- Checked the destination data, issues, and pull requests for duplicates.

## Disclosure

I maintain Agent Coordinator. The entry and pull-request text were drafted and edited with AI assistance, then checked against the linked source and this repository's contribution rules.
