### PR TITLE
Add Okto Nexus to Coordination And Team Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Systems where the central object is the team, company, room, protocol, role, goa
 - [Squad](https://bradygaster.github.io/squad/) ([GitHub](https://github.com/bradygaster/squad)) - Alpha GitHub Copilot-based system where specialist agents live in the repo, keep memory, share decisions, route work through a coordinator, and run in parallel.
 - [Culture](https://culture.dev/) ([GitHub](https://github.com/agentculture/culture)) - Coordination-oriented system with rooms, protocol docs, agent lifecycle patterns, and multiple clients.
 - [Paperclip](https://paperclip.ing/) ([GitHub](https://github.com/paperclipai/paperclip)) - Open-source orchestration for zero-human companies, centered on AI employees, goals, and jobs.
+- [Okto Nexus](https://oktolabs.ai/platform/nexus/) ([GitHub](https://github.com/OktoLabsAI/okto-nexus)) - Elastic-2.0 local-first MCP coordination hub where agents get durable identities, messaging, single-winner handoff claims, and human-in-the-loop approval on risky actions.
 
 ## Not Open But Important
 


### PR DESCRIPTION
Adds Okto Nexus to the Coordination And Team Systems section.

Okto Nexus is a local-first MCP coordination hub for teams of AI coding
agents: durable agent identities and messaging, single-winner handoff
claims so two agents can't start the same work, human-in-the-loop
approval on risky actions, and durable handoff history for session
recovery.

License: Elastic License 2.0 (open-core — free for personal and
commercial use, restricted for hosted/managed-service resale).

Placed alongside Squad, its closest existing entry in this section —
both are systems where the coordinator/handoff layer between agents is
the core product, not a side feature.

Source verified: https://github.com/OktoLabsAI/okto-nexus (README)