### PR TITLE
Add Speakeasy to governance tools

### DIFF
--- a/src/data/orchestrators.ts
+++ b/src/data/orchestrators.ts
@@ -213,6 +213,19 @@ export const governanceTools: OrchestrationToolEntry[] = [
     ctaLabel: "Open governance tool"
   },
   {
+    slug: "speakeasy-mcp-gateway",
+    title: "Speakeasy MCP Gateway",
+    url: "https://www.speakeasy.com/product/mcp-gateway",
+    sourceName: "Speakeasy MCP Gateway product page",
+    mark: "SP",
+    summary:
+      "Commercial MCP gateway that places agents and MCP servers behind one governed entry point.",
+    note:
+      "Routes tool calls through OAuth 2.1 and SSO identity, team- and role-scoped RBAC, runtime guardrails, and audit logs. Included as a commercial governance layer, not an orchestrator.",
+    tags: ["commercial platform", "MCP gateway", "RBAC", "runtime guardrails", "audit logs"],
+    ctaLabel: "Open governance tool"
+  },
+  {
     slug: "settlebridge",
     title: "SettleBridge",
     url: "https://settlebridge.ai/",


### PR DESCRIPTION
Adds Speakeasy to governance tools. It provides a documented agent/MCP governance layer with policy enforcement, access controls, and auditability. Validation: npm test, npm run build, and git diff --check.